### PR TITLE
Rename go-libs to go-appkit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,7 @@ linters-settings:
   lll:
     line-length: 140
   goimports:
-    local-prefixes: github.com/acronis/go-libs/
+    local-prefixes: github.com/acronis/go-appkit/
   gocritic:
     enabled-tags:
       - diagnostic

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Go libraries for writing services/applications.
+# Common Go packages for writing applications, services, and tools
 
 The project includes the following packages:
 
@@ -13,6 +13,7 @@ The project includes the following packages:
 + [restapi](./restapi) - set of simple functions for doing requests and sending responses in the REST API.
 + [retry](./restapi) - helper functions for doing retryable operations.
 + [service](./service) - ready-to-use primitives for creating services and managing their lifecycle.
++ [testutil](./testutil) - helpers for writing tests.
 
 ## Examples
 
@@ -34,13 +35,13 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/acronis/go-libs/config"
-	"github.com/acronis/go-libs/httpserver"
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/profserver"
-	"github.com/acronis/go-libs/restapi"
-	"github.com/acronis/go-libs/service"
+	"github.com/acronis/go-appkit/config"
+	"github.com/acronis/go-appkit/httpserver"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/profserver"
+	"github.com/acronis/go-appkit/restapi"
+	"github.com/acronis/go-appkit/service"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/acronis/go-libs
+module github.com/acronis/go-appkit
 
 go 1.20
 

--- a/httpclient/retryable_round_tripper.go
+++ b/httpclient/retryable_round_tripper.go
@@ -18,8 +18,8 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/retry"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/retry"
 )
 
 // Default parameter values for RetryableRoundTripper.

--- a/httpclient/retryable_round_tripper_test.go
+++ b/httpclient/retryable_round_tripper_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/retry"
+	"github.com/acronis/go-appkit/retry"
 )
 
 type reqInfo struct {

--- a/httpserver/config.go
+++ b/httpserver/config.go
@@ -9,7 +9,7 @@ package httpserver
 import (
 	"time"
 
-	"github.com/acronis/go-libs/config"
+	"github.com/acronis/go-appkit/config"
 )
 
 const (

--- a/httpserver/config_test.go
+++ b/httpserver/config_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/config"
+	"github.com/acronis/go-appkit/config"
 )
 
 func TestConfig(t *testing.T) {

--- a/httpserver/example_test.go
+++ b/httpserver/example_test.go
@@ -15,13 +15,13 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/acronis/go-libs/config"
-	"github.com/acronis/go-libs/httpserver"
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/profserver"
-	"github.com/acronis/go-libs/restapi"
-	"github.com/acronis/go-libs/service"
+	"github.com/acronis/go-appkit/config"
+	"github.com/acronis/go-appkit/httpserver"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/profserver"
+	"github.com/acronis/go-appkit/restapi"
+	"github.com/acronis/go-appkit/service"
 )
 
 /*

--- a/httpserver/health_check.go
+++ b/httpserver/health_check.go
@@ -11,9 +11,9 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 // StatusClientClosedRequest is a special HTTP status code used by Nginx to show that the client

--- a/httpserver/health_check_test.go
+++ b/httpserver/health_check_test.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 func TestHealthCheckHandler_ServeHTTP(t *testing.T) {

--- a/httpserver/http_server.go
+++ b/httpserver/http_server.go
@@ -20,9 +20,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/service"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/service"
 )
 
 // ErrInvalidMaxServingRequests error is returned when maximum number of currently serving requests is negative.

--- a/httpserver/http_server_test.go
+++ b/httpserver/http_server_test.go
@@ -32,11 +32,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
-	"github.com/acronis/go-libs/restapi"
-	"github.com/acronis/go-libs/testutil"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
+	"github.com/acronis/go-appkit/restapi"
+	"github.com/acronis/go-appkit/testutil"
 )
 
 func generateCertificate(certFilePath, privKeyPath string) error {

--- a/httpserver/middleware/context.go
+++ b/httpserver/middleware/context.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 type ctxKey int

--- a/httpserver/middleware/context_test.go
+++ b/httpserver/middleware/context_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func TestGetLoggerFromContext(t *testing.T) {

--- a/httpserver/middleware/example_test.go
+++ b/httpserver/middleware/example_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func Example() {

--- a/httpserver/middleware/in_flight_limit.go
+++ b/httpserver/middleware/in_flight_limit.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/hashicorp/golang-lru/simplelru"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 // DefaultInFlightLimitMaxKeys is a default value of maximum keys number for the InFlightLimit middleware.

--- a/httpserver/middleware/in_flight_limit_test.go
+++ b/httpserver/middleware/in_flight_limit_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
-	"github.com/acronis/go-libs/testutil"
+	"github.com/acronis/go-appkit/testutil"
 )
 
 func TestInFlightLimitHandler_ServeHTTP(t *testing.T) {

--- a/httpserver/middleware/logging.go
+++ b/httpserver/middleware/logging.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/ssgreg/logf"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 const (

--- a/httpserver/middleware/logging_params.go
+++ b/httpserver/middleware/logging_params.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/ssgreg/logf"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 type loggableIntMap map[string]int64

--- a/httpserver/middleware/logging_params_test.go
+++ b/httpserver/middleware/logging_params_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ssgreg/logf"
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func TestLoggingParams_SetTimeSlotDurationMs(t *testing.T) {

--- a/httpserver/middleware/logging_test.go
+++ b/httpserver/middleware/logging_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
 )
 
 type mockLoggingNextHandler struct {

--- a/httpserver/middleware/metrics_test.go
+++ b/httpserver/middleware/metrics_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/acronis/go-libs/testutil"
+	"github.com/acronis/go-appkit/testutil"
 )
 
 type mockHTTPRequestMetricsNextHandler struct {

--- a/httpserver/middleware/rate_limit.go
+++ b/httpserver/middleware/rate_limit.go
@@ -20,8 +20,8 @@ import (
 	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 // DefaultRateLimitMaxKeys is a default value of maximum keys number for the RateLimit middleware.

--- a/httpserver/middleware/recovery.go
+++ b/httpserver/middleware/recovery.go
@@ -11,8 +11,8 @@ import (
 	"net/http"
 	"runtime"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 // RecoveryDefaultStackSize defines the default size of stack part which will be logged.

--- a/httpserver/middleware/recovery_test.go
+++ b/httpserver/middleware/recovery_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
-	"github.com/acronis/go-libs/restapi"
-	"github.com/acronis/go-libs/testutil"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
+	"github.com/acronis/go-appkit/restapi"
+	"github.com/acronis/go-appkit/testutil"
 )
 
 type mockRecoveryNextHandler struct {

--- a/httpserver/middleware/request_body_limit.go
+++ b/httpserver/middleware/request_body_limit.go
@@ -9,7 +9,7 @@ package middleware
 import (
 	"net/http"
 
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 type requestBodyLimitHandler struct {

--- a/httpserver/middleware/request_body_limit_test.go
+++ b/httpserver/middleware/request_body_limit_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 type mockRequestBodyLimitNextHandler struct {

--- a/httpserver/router.go
+++ b/httpserver/router.go
@@ -15,9 +15,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/restapi"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/restapi"
 )
 
 // RouterOpts represents options for creating chi.Router.

--- a/log/config.go
+++ b/log/config.go
@@ -11,7 +11,7 @@ import (
 
 	"code.cloudfoundry.org/bytefmt"
 
-	"github.com/acronis/go-libs/config"
+	"github.com/acronis/go-appkit/config"
 )
 
 const (

--- a/log/config_test.go
+++ b/log/config_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/config"
+	"github.com/acronis/go-appkit/config"
 )
 
 func TestConfig(t *testing.T) {

--- a/log/example_test.go
+++ b/log/example_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/acronis/go-libs/config"
+	"github.com/acronis/go-appkit/config"
 )
 
 /*

--- a/log/logtest/example_test.go
+++ b/log/logtest/example_test.go
@@ -9,7 +9,7 @@ package logtest
 import (
 	"fmt"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func Example() {

--- a/log/logtest/logger.go
+++ b/log/logtest/logger.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/ssgreg/logf"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 type entryWriter struct {

--- a/log/logtest/recorder.go
+++ b/log/logtest/recorder.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/ssgreg/logf"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 // RecordedEntry represents recorded entry which was logged.

--- a/log/logtest/recorder_test.go
+++ b/log/logtest/recorder_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func TestRecorder(t *testing.T) {

--- a/log/prefixed_logger_test.go
+++ b/log/prefixed_logger_test.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
 )
 
 func TestPrefixedLogger(t *testing.T) {

--- a/profserver/config.go
+++ b/profserver/config.go
@@ -6,7 +6,7 @@ Released under MIT license.
 
 package profserver
 
-import "github.com/acronis/go-libs/config"
+import "github.com/acronis/go-appkit/config"
 
 const (
 	cfgKeyProfServerEnabled = "profserver.enabled"

--- a/profserver/prof_server.go
+++ b/profserver/prof_server.go
@@ -14,9 +14,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 
-	"github.com/acronis/go-libs/httpserver/middleware"
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/service"
+	"github.com/acronis/go-appkit/httpserver/middleware"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/service"
 )
 
 // ProfServer represents HTTP server for profiling. pprof is used under the hood.

--- a/profserver/prof_server_test.go
+++ b/profserver/prof_server_test.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log/logtest"
-	"github.com/acronis/go-libs/testutil"
+	"github.com/acronis/go-appkit/log/logtest"
+	"github.com/acronis/go-appkit/testutil"
 )
 
 func TestProfServer_Start(t *testing.T) {

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -14,7 +14,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 const (

--- a/restapi/client_test.go
+++ b/restapi/client_test.go
@@ -18,8 +18,8 @@ import (
 	"testing"
 	"testing/iotest"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/restapi/example_test.go
+++ b/restapi/example_test.go
@@ -15,7 +15,7 @@ import (
 	"net/http/httptest"
 	"path"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func ExampleRespondJSON() {

--- a/restapi/response.go
+++ b/restapi/response.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 // ContentTypeAppJSON represents MIME media type for JSON.

--- a/restapi/response_test.go
+++ b/restapi/response_test.go
@@ -16,9 +16,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log"
-	"github.com/acronis/go-libs/log/logtest"
-	"github.com/acronis/go-libs/testutil"
+	"github.com/acronis/go-appkit/log"
+	"github.com/acronis/go-appkit/log/logtest"
+	"github.com/acronis/go-appkit/testutil"
 )
 
 const testDomain = "TestDomain"

--- a/service/service.go
+++ b/service/service.go
@@ -13,7 +13,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 // Opts represents an options for Service.

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/acronis/go-libs/log/logtest"
+	"github.com/acronis/go-appkit/log/logtest"
 )
 
 func TestService_Start(t *testing.T) {

--- a/service/worker.go
+++ b/service/worker.go
@@ -13,7 +13,7 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 // ErrPeriodicWorkerStop is an error that may be used for interrupting PeriodicWorker's loop.

--- a/service/worker_test.go
+++ b/service/worker_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 
 	"github.com/stretchr/testify/require"
 )

--- a/service/worker_unit_test.go
+++ b/service/worker_unit_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
 
-	"github.com/acronis/go-libs/log"
+	"github.com/acronis/go-appkit/log"
 )
 
 func TestWorkerUnit_Start_Stop(t *testing.T) {


### PR DESCRIPTION
The new name is more specific and better reflects the essence of the content.